### PR TITLE
Added Healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.8
 RUN apk add curl bash ffmpeg && \
     rm -rf /var/cache/apk/*
 COPY stream.sh /usr/bin/stream.sh
+HEALTHCHECK --interval=15s --timeout=1s CMD curl --fail http://localhost:8090/still.jpg --max-time 1 --output /dev/null || exit 1
 RUN chmod +x /usr/bin/stream.sh
 COPY ffserver.conf /etc/ffserver.conf
 ENV RTSP_URL rtsp://freja.hiof.no:1935/rtplive/definst/hessdalen03.stream


### PR DESCRIPTION
I've added the healthcheck to the Dockerfile. It allows Portainer to monitor the health of the container as from time to time this container just stucks.